### PR TITLE
👌 Fix transient absorption scheme for 2 datasets

### DIFF
--- a/pyglotaran_examples/study_transient_absorption/models/scheme_2d_co_co2.yml
+++ b/pyglotaran_examples/study_transient_absorption/models/scheme_2d_co_co2.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=schema_2d.json
 library:
-  cmplx1:
+  base:
     type: kinetic
     rates:
       (s2, s1): "rates.k1"
@@ -8,14 +8,18 @@ library:
       (s4, s2): "rates.k3"
       (s4, s3): "rates.k4"
       (s4, s4): "rates.k5"
+  cmplx1:
+    type: kinetic
+    extends: [base]
+    rates:
       (s5, s5): "rates.kC"
   cmplx2:
     type: kinetic
-    extends: [cmplx1]
+    extends: [base]
     rates:
-      (s4, s2): "rates.k3d2"
-      (s4, s3): "rates.k4d2"
-
+      (s4, s2): "rates.k3d2" # override
+      (s4, s3): "rates.k4d2" # override
+      (s6, s6): "rates.kC"
 
 experiments:
   my_exp:
@@ -30,24 +34,25 @@ experiments:
             center: irf.center
             width: irf.width
             dispersion_center: irf.dispc
-            center_dispersion_coefficients: [irf.disp1,irf.disp2,irf.disp3]
+            center_dispersion_coefficients: [irf.disp1, irf.disp2, irf.disp3]
       dataset2:
-        elements: [cmplx1]
+        elements: [cmplx2]
         activation:
           - type: gaussian
             compartments:
               s1: 1
-              s5: 1
+              s6: 1
             center: irf2.center
             width: irf.width
             dispersion_center: irf.dispc
-            center_dispersion_coefficients: [irf.disp1,irf.disp2,irf.disp3]
+            center_dispersion_coefficients: [irf.disp1, irf.disp2, irf.disp3]
 
         weights:
           - value: 0.1
             global_interval: [280, 550]
           - value: 0.1
             global_interval: [720, 890]
+    # Currently this breaks the optimization result creation:
     clp_relations:
       - source: s2
         target: s3


### PR DESCRIPTION
Dataset 2 should use `cmplx2` instead of `cmplx1`, and the '5th' compartment should be free between the 2 datasets (with same rate) hence the use of s5 in dataset 1 and s6 in dataset 2.